### PR TITLE
Fix dev server directory

### DIFF
--- a/utils/webserver.js
+++ b/utils/webserver.js
@@ -27,7 +27,7 @@ var compiler = webpack(config);
 var server =
     new WebpackDevServer(compiler, {
         hot: true,
-        contentBase: path.join(__dirname, "../build"),
+        contentBase: path.join(__dirname, "../dist"),
         headers: { "Access-Control-Allow-Origin": "*" },
         disableHostCheck: true
     });


### PR DESCRIPTION
## Summary
- fix webserver path to serve from `dist`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f5355fed8832d9f395d03dd3bf8c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the directory used to serve static files during development. Static files are now served from the "dist" folder instead of "build".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->