### PR TITLE
Fix history date display

### DIFF
--- a/src/js/history.js
+++ b/src/js/history.js
@@ -60,7 +60,7 @@ function build_table(historyItems) {
             historyItem.id || "",
             historyItem.url || "",
             historyItem.title || "",
-            new Date(historyItem.lastVisitTime) || "",
+            historyItem.lastVisitTime ? new Date(historyItem.lastVisitTime) : "",
             historyItem.visitCount || "",
             historyItem.typedCount || "",
         ])


### PR DESCRIPTION
## Summary
- handle missing `lastVisitTime` so invalid dates aren't shown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f535657a0832da3ab906be973d717